### PR TITLE
Populate library.properties url field

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -5,5 +5,5 @@ maintainer=mCube <service@mcubemems.com>
 sentence=Library for the MCUBE Module Command Communication
 paragraph=Library for the MCUBE Module Command Communication
 category=Sensors
-url=*
+url=https://github.com/cphuangf/Titan_Arduino_Shield
 architectures=*


### PR DESCRIPTION
A empty url field results in an apparently clickable "More info" link in Library Manager that does nothing.